### PR TITLE
Update default quay.io repo for pushing s2i built images

### DIFF
--- a/config/instances/manuela-quickstart/line-dashboard/kustomization.yaml
+++ b/config/instances/manuela-quickstart/line-dashboard/kustomization.yaml
@@ -16,7 +16,7 @@ bases:
 
 images:
 - name: line-dashboard
-  newName: quay.io/manuela/iot-frontend
+  newName: quay.io/redhat-edge-computing/iot-frontend
   newTag: quickstart
 
 configMapGenerator:

--- a/config/instances/manuela-quickstart/machine-sensor/kustomization.yaml
+++ b/config/instances/manuela-quickstart/machine-sensor/kustomization.yaml
@@ -25,5 +25,5 @@ configMapGenerator:
 
 images:
 - name: machine-sensor
-  newName: quay.io/manuela/iot-software-sensor
+  newName: quay.io/redhat-edge-computing/iot-software-sensor
   newTag: quickstart

--- a/config/instances/manuela-quickstart/messaging/kustomization.yaml
+++ b/config/instances/manuela-quickstart/messaging/kustomization.yaml
@@ -16,5 +16,5 @@ bases:
 
 images:
 - name: messaging
-  newName: quay.io/manuela/iot-consumer
+  newName: quay.io/redhat-edge-computing/iot-consumer
   newTag: quickstart

--- a/config/templates/manuela-openshift-prod/anomaly-detection/anomaly-detection-is.yaml
+++ b/config/templates/manuela-openshift-prod/anomaly-detection/anomaly-detection-is.yaml
@@ -7,35 +7,35 @@ spec:
   - name: 0.3.2-28
     from:
       kind: DockerImage
-      name: quay.io/manuela/iot-anomaly-detection:0.3.2-28
+      name: quay.io/redhat-edge-computing/iot-anomaly-detection:0.3.2-28
     importPolicy: {}
     referencePolicy:
       type: Local
   - name: 0.3.2-29
     from:
       kind: DockerImage
-      name: quay.io/manuela/iot-anomaly-detection:0.3.2-29
+      name: quay.io/redhat-edge-computing/iot-anomaly-detection:0.3.2-29
     importPolicy: {}
     referencePolicy:
       type: Local
   - name: 0.3.2-30
     from:
       kind: DockerImage
-      name: quay.io/manuela/iot-anomaly-detection:0.3.2-30
+      name: quay.io/redhat-edge-computing/iot-anomaly-detection:0.3.2-30
     importPolicy: {}
     referencePolicy:
       type: Local
   - name: 0.3.2-31
     from:
       kind: DockerImage
-      name: quay.io/manuela/iot-anomaly-detection:0.3.2-31
+      name: quay.io/redhat-edge-computing/iot-anomaly-detection:0.3.2-31
     importPolicy: {}
     referencePolicy:
       type: Local
   - name: 0.3.2-32
     from:
       kind: DockerImage
-      name: quay.io/manuela/iot-anomaly-detection:0.3.2-32
+      name: quay.io/redhat-edge-computing/iot-anomaly-detection:0.3.2-32
     importPolicy: {}
     referencePolicy:
       type: Local

--- a/config/templates/manuela-openshift-prod/line-dashboard/line-dashboard-is.yaml
+++ b/config/templates/manuela-openshift-prod/line-dashboard/line-dashboard-is.yaml
@@ -7,49 +7,49 @@ spec:
   - name: 0.3.1-46
     from:
       kind: DockerImage
-      name: quay.io/manuela/iot-frontend:0.3.1-46
+      name: quay.io/redhat-edge-computing/iot-frontend:0.3.1-46
     importPolicy: {}
     referencePolicy:
       type: Local
   - name: 0.3.1-49
     from:
       kind: DockerImage
-      name: quay.io/manuela/iot-frontend:0.3.1-49
+      name: quay.io/redhat-edge-computing/iot-frontend:0.3.1-49
     importPolicy: {}
     referencePolicy:
       type: Local
   - name: 0.3.1-52
     from:
       kind: DockerImage
-      name: quay.io/manuela/iot-frontend:0.3.1-52
+      name: quay.io/redhat-edge-computing/iot-frontend:0.3.1-52
     importPolicy: {}
     referencePolicy:
       type: Local
   - name: 0.3.1-53
     from:
       kind: DockerImage
-      name: quay.io/manuela/iot-frontend:0.3.1-53
+      name: quay.io/redhat-edge-computing/iot-frontend:0.3.1-53
     importPolicy: {}
     referencePolicy:
       type: Local
   - name: 0.3.1-54
     from:
       kind: DockerImage
-      name: quay.io/manuela/iot-frontend:0.3.1-54
+      name: quay.io/redhat-edge-computing/iot-frontend:0.3.1-54
     importPolicy: {}
     referencePolicy:
       type: Local
   - name: 0.3.1-55
     from:
       kind: DockerImage
-      name: quay.io/manuela/iot-frontend:0.3.1-55
+      name: quay.io/redhat-edge-computing/iot-frontend:0.3.1-55
     importPolicy: {}
     referencePolicy:
       type: Local
   - name: 0.3.1-56
     from:
       kind: DockerImage
-      name: quay.io/manuela/iot-frontend:0.3.1-56
+      name: quay.io/redhat-edge-computing/iot-frontend:0.3.1-56
     importPolicy: {}
     referencePolicy:
       type: Local

--- a/config/templates/manuela-openshift-prod/machine-sensor/machine-sensor-is.yaml
+++ b/config/templates/manuela-openshift-prod/machine-sensor/machine-sensor-is.yaml
@@ -7,49 +7,49 @@ spec:
   - name: 0.3.1-24
     from:
       kind: DockerImage
-      name: quay.io/manuela/iot-software-sensor:0.3.1-24
+      name: quay.io/redhat-edge-computing/iot-software-sensor:0.3.1-24
     importPolicy: {}
     referencePolicy:
       type: Local
   - name: 0.3.1-25
     from:
       kind: DockerImage
-      name: quay.io/manuela/iot-software-sensor:0.3.1-25
+      name: quay.io/redhat-edge-computing/iot-software-sensor:0.3.1-25
     importPolicy: {}
     referencePolicy:
       type: Local
   - name: 0.3.1-27
     from:
       kind: DockerImage
-      name: quay.io/manuela/iot-software-sensor:0.3.1-27
+      name: quay.io/redhat-edge-computing/iot-software-sensor:0.3.1-27
     importPolicy: {}
     referencePolicy:
       type: Local
   - name: 0.3.1-28
     from:
       kind: DockerImage
-      name: quay.io/manuela/iot-software-sensor:0.3.1-28
+      name: quay.io/redhat-edge-computing/iot-software-sensor:0.3.1-28
     importPolicy: {}
     referencePolicy:
       type: Local
   - name: 0.3.1-29
     from:
       kind: DockerImage
-      name: quay.io/manuela/iot-software-sensor:0.3.1-29
+      name: quay.io/redhat-edge-computing/iot-software-sensor:0.3.1-29
     importPolicy: {}
     referencePolicy:
       type: Local
   - name: 0.3.1-30
     from:
       kind: DockerImage
-      name: quay.io/manuela/iot-software-sensor:0.3.1-30
+      name: quay.io/redhat-edge-computing/iot-software-sensor:0.3.1-30
     importPolicy: {}
     referencePolicy:
       type: Local
   - name: 0.3.1-31
     from:
       kind: DockerImage
-      name: quay.io/manuela/iot-software-sensor:0.3.1-31
+      name: quay.io/redhat-edge-computing/iot-software-sensor:0.3.1-31
     importPolicy: {}
     referencePolicy:
       type: Local

--- a/config/templates/manuela-openshift-prod/messaging/messaging-is.yaml
+++ b/config/templates/manuela-openshift-prod/messaging/messaging-is.yaml
@@ -7,49 +7,49 @@ spec:
   - name: 0.3.2-38
     from:
       kind: DockerImage
-      name: quay.io/manuela/iot-consumer:0.3.2-38
+      name: quay.io/redhat-edge-computing/iot-consumer:0.3.2-38
     importPolicy: {}
     referencePolicy:
       type: Local
   - name: 0.3.2-39
     from:
       kind: DockerImage
-      name: quay.io/manuela/iot-consumer:0.3.2-39
+      name: quay.io/redhat-edge-computing/iot-consumer:0.3.2-39
     importPolicy: {}
     referencePolicy:
       type: Local
   - name: 0.3.2-40
     from:
       kind: DockerImage
-      name: quay.io/manuela/iot-consumer:0.3.2-40
+      name: quay.io/redhat-edge-computing/iot-consumer:0.3.2-40
     importPolicy: {}
     referencePolicy:
       type: Local
   - name: 0.3.2-41
     from:
       kind: DockerImage
-      name: quay.io/manuela/iot-consumer:0.3.2-41
+      name: quay.io/redhat-edge-computing/iot-consumer:0.3.2-41
     importPolicy: {}
     referencePolicy:
       type: Local
   - name: 0.3.2-42
     from:
       kind: DockerImage
-      name: quay.io/manuela/iot-consumer:0.3.2-42
+      name: quay.io/redhat-edge-computing/iot-consumer:0.3.2-42
     importPolicy: {}
     referencePolicy:
       type: Local
   - name: 0.3.2-43
     from:
       kind: DockerImage
-      name: quay.io/manuela/iot-consumer:0.3.2-43
+      name: quay.io/redhat-edge-computing/iot-consumer:0.3.2-43
     importPolicy: {}
     referencePolicy:
       type: Local
   - name: 0.3.2-46
     from:
       kind: DockerImage
-      name: quay.io/manuela/iot-consumer:0.3.2-46
+      name: quay.io/redhat-edge-computing/iot-consumer:0.3.2-46
     importPolicy: {}
     referencePolicy:
       type: Local


### PR DESCRIPTION
Move default image repository images to quay.io/redhat-edge-computing

Signed-off-by: Landon LaSmith <LLaSmith@redhat.com>