### PR TITLE
Add argocd application for gcp factory deployment

### DIFF
--- a/meta/argocd-staging-gcp-factorydatacenter.yaml
+++ b/meta/argocd-staging-gcp-factorydatacenter.yaml
@@ -1,0 +1,29 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: factorydatacenter
+  namespace: argocd
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/redhat-edge-computing/manuela-gitops.git
+    targetRevision: HEAD
+    path: deployment/staging-gcp-factorydatacenter
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: argocd
+  syncPolicy:
+    automated: 
+      prune: true
+      selfHeal: true
+  ignoreDifferences:
+  - group: apps
+    kind: Deployment
+    jsonPointers:
+    - /spec/replicas
+  - group: route.openshift.io
+    kind: Route
+    jsonPointers:
+    - /status


### PR DESCRIPTION
There was no argocd meta application to deploy the factorydatacenter that is currently available with a staging-gcp deployment

Signed-off-by: Landon LaSmith <LLaSmith@redhat.com>