### PR TITLE
Correct aws application sensor reference

### DIFF
--- a/config/instances/manuela-stormshift-staging-aws/manuela-stormshift-machine-sensor-application.yaml
+++ b/config/instances/manuela-stormshift-staging-aws/manuela-stormshift-machine-sensor-application.yaml
@@ -10,7 +10,7 @@ spec:
   source:
     repoURL: https://github.com/redhat-edge-computing/manuela-gitops.git
     targetRevision: HEAD
-    path: config/instances/manuela-stormshift/machine-sensor
+    path: config/instances/manuela-stormshift-staging-aws/machine-sensor
   destination:
     server: https://kubernetes.default.svc
     namespace: manuela-stormshift-machine-sensor


### PR DESCRIPTION
Fix an incorrect application path in the machine-sensor for AWS

Signed-off-by: Landon LaSmith <LLaSmith@redhat.com>